### PR TITLE
Modernize UI with basic shadcn components

### DIFF
--- a/components/FamilyTree.js
+++ b/components/FamilyTree.js
@@ -1,11 +1,13 @@
+import Card from './ui/Card'
+
 export default function FamilyTree({ data }) {
   const buildTree = (parentId = null) => {
     return data.members
       .filter(member => member.parentId === parentId)
       .map(member => (
-        <li key={member.id}>
-          {member.name}
-          <ul>{buildTree(member.id)}</ul>
+        <li key={member.id} className="mb-2">
+          <Card className="inline-block">{member.name}</Card>
+          <ul className="pl-4 mt-2">{buildTree(member.id)}</ul>
         </li>
       ))
   }

--- a/components/ui/Button.js
+++ b/components/ui/Button.js
@@ -1,0 +1,18 @@
+export default function Button({ className = '', style = {}, ...props }) {
+  return (
+    <button
+      style={{
+        padding: '0.5rem 1rem',
+        borderRadius: '0.375rem',
+        backgroundColor: '#111',
+        color: '#fff',
+        transition: 'background-color 0.2s',
+        ...style,
+      }}
+      className={className}
+      onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#333')}
+      onMouseOut={(e) => (e.currentTarget.style.backgroundColor = '#111')}
+      {...props}
+    />
+  )
+}

--- a/components/ui/Card.js
+++ b/components/ui/Card.js
@@ -1,0 +1,17 @@
+export default function Card({ className = '', style = {}, children }) {
+  return (
+    <div
+      className={className}
+      style={{
+        padding: '1rem',
+        border: '1px solid #e5e7eb',
+        borderRadius: '0.375rem',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+        display: 'inline-block',
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/ui/Input.js
+++ b/components/ui/Input.js
@@ -1,0 +1,22 @@
+export default function Input({ className = '', style = {}, ...props }) {
+  return (
+    <input
+      style={{
+        border: '1px solid #d1d5db',
+        borderRadius: '0.375rem',
+        padding: '0.5rem 0.75rem',
+        outline: 'none',
+        width: '100%',
+        ...style,
+      }}
+      onFocus={(e) => {
+        e.currentTarget.style.boxShadow = '0 0 0 2px #000';
+      }}
+      onBlur={(e) => {
+        e.currentTarget.style.boxShadow = 'none';
+      }}
+      className={className}
+      {...props}
+    />
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import FamilyTree from '../components/FamilyTree'
 import familyData from '../data/family.json'
+import Button from '../components/ui/Button'
+import Input from '../components/ui/Input'
 
 export default function Home() {
   const [data, setData] = useState(familyData)
@@ -22,24 +24,24 @@ export default function Home() {
   }
 
   return (
-    <div>
-      <h1>Family Tree</h1>
+    <div className="container" style={{ padding: '1rem' }}>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>Family Tree</h1>
       <FamilyTree data={data} />
-      <h2>Add Family Member</h2>
-      <form onSubmit={handleAdd}>
-        <input
+      <h2 style={{ fontSize: '1.25rem', fontWeight: 600, marginTop: '2rem', marginBottom: '0.5rem' }}>Add Family Member</h2>
+      <form onSubmit={handleAdd} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <Input
           type="text"
           placeholder="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <input
+        <Input
           type="number"
           placeholder="Parent ID"
           value={parentId}
           onChange={(e) => setParentId(e.target.value)}
         />
-        <button type="submit">Add</button>
+        <Button type="submit" style={{ width: '100%' }}>Add</Button>
       </form>
     </div>
   )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,12 @@
 body {
   font-family: Arial, sans-serif;
   padding: 20px;
+  background-color: #f9f9f9;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
 }
 
 ul {


### PR DESCRIPTION
## Summary
- add minimalist Card, Button, and Input components
- rebuild FamilyTree to use Card display
- refactor index page to use new components
- style the page container

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fd27746083298686a33644f556b5